### PR TITLE
Before upload

### DIFF
--- a/src/js/plupload-angular-directive.js
+++ b/src/js/plupload-angular-directive.js
@@ -129,6 +129,13 @@ angular.module('plupload.directive', [])
 						uploader.start();
 					}
 				});
+				
+                uploader.bind('BeforeUpload', function(up, file) {
+                    if(iAttrs.onBeforeUpload){
+                        var fn = $parse(iAttrs.onBeforeUpload);
+               			fn(scope.$parent, {$file:file});
+                    }
+                });
 
 				uploader.bind('FileUploaded', function(up, file, res) {
 					if(iAttrs.onFileUploaded) {


### PR DESCRIPTION
Adds a Before Upload event to the directive.  This is necessary if you want to send additional meta data with each file upload.